### PR TITLE
Alphanet bug fix

### DIFF
--- a/nft/Cargo.toml
+++ b/nft/Cargo.toml
@@ -42,7 +42,8 @@ frame-election-provider-support = { workspace = true, default-features = false }
 pallet-timestamp = { workspace = true, default-features = false }
 pallet-staking = { workspace = true, default-features = false }
 pallet-staking-reward-curve = { workspace = true, default-features = false }
-pallet-session = { workspace = true, default-features = false }
+pallet-session = { workspace = true, default-features = false, features = [
+	"historical" ]}
 sp-staking = { workspace = true, default-features = false }
 
 [features]

--- a/nft/src/tests/extrinsics.rs
+++ b/nft/src/tests/extrinsics.rs
@@ -69,7 +69,8 @@ fn prepare_tee_for_tests() {
 	let bob: mock::RuntimeOrigin = origin(BOB);
 	let charlie: mock::RuntimeOrigin = origin(CHARLIE);
 
-	let api_uri: BoundedVec<u8, MaxUriLen>= b"test".to_vec().try_into().unwrap();
+	let api_uri: BoundedVec<u8, MaxUriLen> = b"test".to_vec().try_into().unwrap();
+	start_active_era(1);
 
 	assert_ok!(TEE::register_enclave(alice.clone(), ALICE_ENCLAVE, api_uri.clone()));
 	assert_ok!(TEE::register_enclave(bob.clone(), BOB_ENCLAVE, api_uri.clone()));
@@ -83,6 +84,11 @@ fn prepare_tee_for_tests() {
 	assert_ok!(TEE::assign_enclave(root(), ALICE, cluster_id, 0));
 	assert_ok!(TEE::assign_enclave(root(), BOB, cluster_id, 1));
 	assert_ok!(TEE::assign_enclave(root(), CHARLIE, second_cluster_id, 2));
+
+	// let raw = (4 as sp_staking::EraIndex, Some(10u64)).encode();
+	// let info = pallet_staking::ActiveEraInfo::decode(&mut &raw[..]).unwrap();
+	// pallet_staking::ActiveEra::<T>::put(&info);
+	// Change current block.
 }
 
 mod create_nft {
@@ -1863,13 +1869,15 @@ mod add_secret_shard {
 
 	#[test]
 	fn nft_not_found() {
-		ExtBuilder::new_build(vec![(ALICE, 1000), (BOB, 1000), (CHARLIE, 1000)]).execute_with(|| {
-			prepare_tests();
-			prepare_tee_for_tests();
-			let alice_enclave: mock::RuntimeOrigin = origin(ALICE_ENCLAVE);
-			let err = NFT::add_secret_shard(alice_enclave, INVALID_ID);
-			assert_noop!(err, Error::<Test>::NFTNotFound);
-		})
+		ExtBuilder::new_build(vec![(ALICE, 1000), (BOB, 1000), (CHARLIE, 1000)]).execute_with(
+			|| {
+				prepare_tests();
+				prepare_tee_for_tests();
+				let alice_enclave: mock::RuntimeOrigin = origin(ALICE_ENCLAVE);
+				let err = NFT::add_secret_shard(alice_enclave, INVALID_ID);
+				assert_noop!(err, Error::<Test>::NFTNotFound);
+			},
+		)
 	}
 
 	#[test]
@@ -2703,13 +2711,15 @@ mod add_capsule_shard {
 
 	#[test]
 	fn nft_not_found() {
-		ExtBuilder::new_build(vec![(ALICE, 1000), (BOB, 1000), (CHARLIE, 1000)]).execute_with(|| {
-			prepare_tests();
-			prepare_tee_for_tests();
-			let alice_enclave: mock::RuntimeOrigin = origin(ALICE_ENCLAVE);
-			let err = NFT::add_capsule_shard(alice_enclave, INVALID_ID);
-			assert_noop!(err, Error::<Test>::NFTNotFound);
-		})
+		ExtBuilder::new_build(vec![(ALICE, 1000), (BOB, 1000), (CHARLIE, 1000)]).execute_with(
+			|| {
+				prepare_tests();
+				prepare_tee_for_tests();
+				let alice_enclave: mock::RuntimeOrigin = origin(ALICE_ENCLAVE);
+				let err = NFT::add_capsule_shard(alice_enclave, INVALID_ID);
+				assert_noop!(err, Error::<Test>::NFTNotFound);
+			},
+		)
 	}
 
 	#[test]

--- a/tee/Cargo.toml
+++ b/tee/Cargo.toml
@@ -43,7 +43,8 @@ sp-io = { workspace = true, default-features = false }
 frame-election-provider-support = { workspace = true, default-features = false }
 pallet-timestamp = { workspace = true, default-features = false }
 pallet-staking-reward-curve = { workspace = true, default-features = false }
-pallet-session = { workspace = true, default-features = false }
+pallet-session = { workspace = true, default-features = false, features = [
+	"historical" ]}
 pallet-staking = { workspace = true, default-features = false }
 
 

--- a/tee/src/benchmarking.rs
+++ b/tee/src/benchmarking.rs
@@ -70,6 +70,10 @@ benchmarks! {
 		let uri: BoundedVec<u8, T::MaxUriLen> = BoundedVec::try_from(vec![1; T::MaxUriLen::get() as usize]).unwrap();
 		let enclave = Enclave::new(enclave_address.clone(), uri.clone());
 
+		let raw = (4 as sp_staking::EraIndex, Some(10u64)).encode();
+		let info = pallet_staking::ActiveEraInfo::decode(&mut &raw[..]).unwrap();
+		pallet_staking::ActiveEra::<T>::put(&info);
+
 		TEE::<T>::create_cluster(RawOrigin::Root.into(), ClusterType::Public).unwrap();
 		TEE::<T>::register_enclave(origin::<T>("ALICE").into(), enclave_address.clone(), uri.clone()).unwrap();
 		TEE::<T>::assign_enclave(RawOrigin::Root.into(), alice.clone(), cluster_id, slot_id).unwrap();
@@ -83,6 +87,10 @@ benchmarks! {
 		let enclave_address: T::AccountId= get_account::<T>("ALICE_ENCLAVE");
 		let uri: BoundedVec<u8, T::MaxUriLen> = BoundedVec::try_from(vec![1; T::MaxUriLen::get() as usize]).unwrap();
 		let enclave = Enclave::new(enclave_address.clone(), uri.clone());
+
+		let raw = (4 as sp_staking::EraIndex, Some(10u64)).encode();
+		let info = pallet_staking::ActiveEraInfo::decode(&mut &raw[..]).unwrap();
+		pallet_staking::ActiveEra::<T>::put(&info);
 
 		TEE::<T>::create_cluster(RawOrigin::Root.into(), ClusterType::Public).unwrap();
 		TEE::<T>::register_enclave(origin::<T>("ALICE").into(), enclave_address.clone(), uri.clone()).unwrap();
@@ -107,6 +115,10 @@ benchmarks! {
 		let uri: BoundedVec<u8, T::MaxUriLen> = BoundedVec::try_from(vec![1; T::MaxUriLen::get() as usize]).unwrap();
 		let enclave = Enclave::new(enclave_address.clone(), uri.clone());
 
+		let raw = (4 as sp_staking::EraIndex, Some(10u64)).encode();
+		let info = pallet_staking::ActiveEraInfo::decode(&mut &raw[..]).unwrap();
+		pallet_staking::ActiveEra::<T>::put(&info);
+
 		TEE::<T>::create_cluster(RawOrigin::Root.into(), ClusterType::Public).unwrap();
 		TEE::<T>::register_enclave(origin::<T>("ALICE").into(), enclave_address.clone(), uri.clone()).unwrap();
 		TEE::<T>::assign_enclave(RawOrigin::Root.into(), alice.clone(), cluster_id, slot_id).unwrap();
@@ -125,6 +137,11 @@ benchmarks! {
 		let enclave_address: T::AccountId= get_account::<T>("ALICE_ENCLAVE");
 		let uri: BoundedVec<u8, T::MaxUriLen> = BoundedVec::try_from(vec![1; T::MaxUriLen::get() as usize]).unwrap();
 		let enclave = Enclave::new(enclave_address.clone(), uri.clone());
+
+		let raw = (4 as sp_staking::EraIndex, Some(10u64)).encode();
+		let info = pallet_staking::ActiveEraInfo::decode(&mut &raw[..]).unwrap();
+		pallet_staking::ActiveEra::<T>::put(&info);
+
 		TEE::<T>::create_cluster(RawOrigin::Root.into(), ClusterType::Public).unwrap();
 		TEE::<T>::register_enclave(origin::<T>("ALICE").into(), enclave_address.clone(), uri.clone()).unwrap();
 
@@ -158,6 +175,10 @@ benchmarks! {
 		let uri: BoundedVec<u8, T::MaxUriLen> = BoundedVec::try_from(vec![1; T::MaxUriLen::get() as usize]).unwrap();
 		let enclave = Enclave::new(enclave_address.clone(), uri.clone());
 
+		let raw = (4 as sp_staking::EraIndex, Some(10u64)).encode();
+		let info = pallet_staking::ActiveEraInfo::decode(&mut &raw[..]).unwrap();
+		pallet_staking::ActiveEra::<T>::put(&info);
+
 		TEE::<T>::create_cluster(RawOrigin::Root.into(), ClusterType::Public).unwrap();
 		TEE::<T>::register_enclave(origin::<T>("ALICE").into(), enclave_address.clone(), uri.clone()).unwrap();
 		TEE::<T>::assign_enclave(RawOrigin::Root.into(), alice.clone(), cluster_id, slot_id).unwrap();
@@ -181,6 +202,10 @@ benchmarks! {
 		let uri: BoundedVec<u8, T::MaxUriLen> = BoundedVec::try_from(vec![1; T::MaxUriLen::get() as usize]).unwrap();
 		let enclave = Enclave::new(enclave_address.clone(), uri.clone());
 
+		let raw = (4 as sp_staking::EraIndex, Some(10u64)).encode();
+		let info = pallet_staking::ActiveEraInfo::decode(&mut &raw[..]).unwrap();
+		pallet_staking::ActiveEra::<T>::put(&info);
+
 		TEE::<T>::create_cluster(RawOrigin::Root.into(), ClusterType::Public).unwrap();
 		TEE::<T>::register_enclave(origin::<T>("ALICE").into(), enclave_address.clone(), uri.clone()).unwrap();
 		TEE::<T>::assign_enclave(RawOrigin::Root.into(), alice.clone(), cluster_id, slot_id).unwrap();
@@ -201,6 +226,10 @@ benchmarks! {
 		let enclave_address: T::AccountId= get_account::<T>("ALICE_ENCLAVE");
 		let uri: BoundedVec<u8, T::MaxUriLen> = BoundedVec::try_from(vec![1; T::MaxUriLen::get() as usize]).unwrap();
 		let enclave = Enclave::new(enclave_address.clone(), uri.clone());
+
+		let raw = (4 as sp_staking::EraIndex, Some(10u64)).encode();
+		let info = pallet_staking::ActiveEraInfo::decode(&mut &raw[..]).unwrap();
+		pallet_staking::ActiveEra::<T>::put(&info);
 
 		TEE::<T>::create_cluster(RawOrigin::Root.into(), ClusterType::Public).unwrap();
 		TEE::<T>::register_enclave(origin::<T>("ALICE").into(), enclave_address.clone(), uri.clone()).unwrap();
@@ -279,6 +308,10 @@ benchmarks! {
 		let enclave_address: T::AccountId= get_account::<T>("ALICE_ENCLAVE");
 		let uri: BoundedVec<u8, T::MaxUriLen> = BoundedVec::try_from(vec![1; T::MaxUriLen::get() as usize]).unwrap();
 
+		let raw = (4 as sp_staking::EraIndex, Some(10u64)).encode();
+		let info = pallet_staking::ActiveEraInfo::decode(&mut &raw[..]).unwrap();
+		pallet_staking::ActiveEra::<T>::put(&info);
+
 		TEE::<T>::create_cluster(RawOrigin::Root.into(), ClusterType::Public).unwrap();
 		TEE::<T>::register_enclave(origin::<T>("ALICE").into(), enclave_address.clone(), uri.clone()).unwrap();
 		TEE::<T>::assign_enclave(RawOrigin::Root.into(), alice.clone(), cluster_id, slot_id).unwrap();
@@ -300,6 +333,10 @@ benchmarks! {
 		let slot_id: SlotId = 0;
 		let enclave_address: T::AccountId= get_account::<T>("ALICE_ENCLAVE");
 		let uri: BoundedVec<u8, T::MaxUriLen> = BoundedVec::try_from(vec![1; T::MaxUriLen::get() as usize]).unwrap();
+
+		let raw = (4 as sp_staking::EraIndex, Some(10u64)).encode();
+		let info = pallet_staking::ActiveEraInfo::decode(&mut &raw[..]).unwrap();
+		pallet_staking::ActiveEra::<T>::put(&info);
 
 		TEE::<T>::create_cluster(RawOrigin::Root.into(), ClusterType::Public).unwrap();
 		TEE::<T>::register_enclave(origin::<T>("ALICE").into(), enclave_address.clone(), uri.clone()).unwrap();
@@ -420,7 +457,11 @@ benchmarks! {
 		};
 		TEE::<T>::submit_metrics_server_report(origin::<T>("ALICE").into(), alice.clone(), metrics_server_report).unwrap();
 
-	}: _(origin::<T>("ALICE"), 2)
+		let raw = (15 as sp_staking::EraIndex, Some(15u64)).encode();
+		let info = pallet_staking::ActiveEraInfo::decode(&mut &raw[..]).unwrap();
+		pallet_staking::ActiveEra::<T>::put(&info);
+
+	}: _(origin::<T>("ALICE"), 10)
 
 	update_operator_assigned_era {
 		prepare_benchmarks::<T>();
@@ -468,7 +509,7 @@ benchmarks! {
 		TEE::<T>::set_staking_amount(RawOrigin::Root.into(), stake_amount).unwrap();
 	}: _(origin::<T>("ALICE"))
 	verify {
-		assert_eq!(OperatorAssignedEra::<T>::get(alice).unwrap(), 11);
+		assert_eq!(OperatorAssignedEra::<T>::get(alice).unwrap(), 10);
 	}
 
 	refund_excess {
@@ -494,7 +535,7 @@ benchmarks! {
 		TEE::<T>::set_staking_amount(RawOrigin::Root.into(), stake_amount).unwrap();
 	}: _(origin::<T>("ALICE"))
 	verify {
-		assert_eq!(OperatorAssignedEra::<T>::get(alice).unwrap(), 11);
+		assert_eq!(OperatorAssignedEra::<T>::get(alice).unwrap(), 10);
 	}
 }
 

--- a/tee/src/lib.rs
+++ b/tee/src/lib.rs
@@ -41,7 +41,7 @@ use sp_std::vec;
 use primitives::tee::{ClusterId, SlotId};
 use sp_runtime::{
 	traits::{AccountIdConversion, CheckedSub, SaturatedConversion},
-	Perbill, Percent,
+	Perbill, Percent, Saturating,
 };
 use ternoa_common::traits;
 pub use weights::WeightInfo;
@@ -198,7 +198,7 @@ pub mod pallet {
 		_,
 		Blake2_128Concat,
 		T::AccountId,
-		TeeStakingLedger<T::AccountId, T::BlockNumber>,
+		TeeStakingLedger<T::AccountId, T::BlockNumber, BalanceOf<T>>,
 		OptionQuery,
 	>;
 
@@ -237,6 +237,11 @@ pub mod pallet {
 		OptionQuery,
 	>;
 
+	#[pallet::storage]
+	#[pallet::getter(fn operator_assigned_block_number)]
+	pub type OperatorAssignedEra<T: Config> =
+		StorageMap<_, Blake2_128Concat, T::AccountId, EraIndex, OptionQuery>;
+
 	#[pallet::hooks]
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
 		fn on_runtime_upgrade() -> frame_support::weights::Weight {
@@ -269,14 +274,9 @@ pub mod pallet {
 			};
 
 			if let Some(current_active_era) = current_active_era {
-				let fetch_event = Event::FetchedEra { current_active_era };
-				Self::deposit_event(fetch_event);
 				// Clean old era information.
 				if let Some(old_era) = current_active_era.checked_sub(T::TeeHistoryDepth::get()) {
 					Self::clear_old_era(old_era);
-
-					let success_event = Event::ClearedOldEra { old_era };
-					Self::deposit_event(success_event);
 				}
 			}
 			T::DbWeight::get().reads_writes(read, write)
@@ -293,30 +293,17 @@ pub mod pallet {
 			api_uri: BoundedVec<u8, T::MaxUriLen>,
 		},
 		/// An enclave got unregistered
-		RegistrationRemoved {
-			operator_address: T::AccountId,
-		},
+		RegistrationRemoved { operator_address: T::AccountId },
 		/// An enclave update request was cancelled by operator
-		UpdateRequestCancelled {
-			operator_address: T::AccountId,
-		},
+		UpdateRequestCancelled { operator_address: T::AccountId },
 		/// An enclave update request was removed
-		UpdateRequestRemoved {
-			operator_address: T::AccountId,
-		},
+		UpdateRequestRemoved { operator_address: T::AccountId },
 		/// An enclave moved for unregistration to a queue
-		MovedForUnregistration {
-			operator_address: T::AccountId,
-		},
+		MovedForUnregistration { operator_address: T::AccountId },
 		/// An enclave got assigned to a cluster
-		EnclaveAssigned {
-			operator_address: T::AccountId,
-			cluster_id: ClusterId,
-		},
+		EnclaveAssigned { operator_address: T::AccountId, cluster_id: ClusterId },
 		/// An enclave got removed
-		EnclaveRemoved {
-			operator_address: T::AccountId,
-		},
+		EnclaveRemoved { operator_address: T::AccountId },
 		/// An enclave was added to the update list
 		MovedForUpdate {
 			operator_address: T::AccountId,
@@ -329,52 +316,35 @@ pub mod pallet {
 			new_enclave_address: T::AccountId,
 			new_api_uri: BoundedVec<u8, T::MaxUriLen>,
 		},
+		/// Enclave updated
+		EnclaveForceUpdated {
+			operator_address: T::AccountId,
+			new_enclave_address: Option<T::AccountId>,
+			new_api_uri: Option<BoundedVec<u8, T::MaxUriLen>>,
+		},
 		/// New cluster got added
-		ClusterAdded {
-			cluster_id: ClusterId,
-			cluster_type: ClusterType,
-		},
+		ClusterAdded { cluster_id: ClusterId, cluster_type: ClusterType },
 		///Cluster got update
-		ClusterUpdated {
-			cluster_id: ClusterId,
-			cluster_type: ClusterType,
-		},
+		ClusterUpdated { cluster_id: ClusterId, cluster_type: ClusterType },
 		/// Cluster got removed
-		ClusterRemoved {
-			cluster_id: ClusterId,
-		},
+		ClusterRemoved { cluster_id: ClusterId },
 		/// Staking amount changed.
-		StakingAmountSet {
-			staking_amount: BalanceOf<T>,
-		},
+		StakingAmountSet { staking_amount: BalanceOf<T> },
 		/// Bonded while enclave registration
-		Bonded {
-			operator_address: T::AccountId,
-			amount: BalanceOf<T>,
-		},
+		Bonded { operator_address: T::AccountId, amount: BalanceOf<T> },
 		/// An account has unbonded this amount.
-		Unbonded {
-			operator_address: T::AccountId,
-			amount: BalanceOf<T>,
-		},
+		Unbonded { operator_address: T::AccountId, amount: BalanceOf<T> },
 		/// Withdrawn the bonded amount
-		Withdrawn {
-			operator_address: T::AccountId,
-			amount: BalanceOf<T>,
-		},
+		Withdrawn { operator_address: T::AccountId, amount: BalanceOf<T> },
 		/// New metrics server got added
-		MetricsServerAdded {
-			metrics_server: MetricsServer<T::AccountId>,
-		},
+		MetricsServerAdded { metrics_server: MetricsServer<T::AccountId> },
 		/// Updated metrics server cluster type
 		MetricsServerTypeUpdated {
 			metrics_server_address: T::AccountId,
 			new_supported_cluster_type: ClusterType,
 		},
 		/// Removed a metrics server
-		MetricsServerRemoved {
-			metrics_server_address: T::AccountId,
-		},
+		MetricsServerRemoved { metrics_server_address: T::AccountId },
 		/// Metrics server report submitted
 		MetricsServerReportSubmitted {
 			era: EraIndex,
@@ -390,36 +360,19 @@ pub mod pallet {
 			param_5_weightage: u8,
 		},
 		/// Rewards claimed by operator
-		RewardsClaimed {
-			era: EraIndex,
-			operator_address: T::AccountId,
-			amount: BalanceOf<T>,
-		},
+		RewardsClaimed { era: EraIndex, operator_address: T::AccountId, amount: BalanceOf<T> },
 		/// Fetching active era during the last session in an era
-		FailedToGetActiveEra {
-			block_number: T::BlockNumber,
-		},
+		FailedToGetActiveEra { block_number: T::BlockNumber },
 		/// Staking amount is set
-		StakingAmountIsSet {
-			amount: BalanceOf<T>,
-		},
+		StakingAmountIsSet { amount: BalanceOf<T> },
 		/// Reward amount is set
-		RewardAmountIsSet {
-			amount: BalanceOf<T>,
-		},
-		/// Fetching active era during the last session in an era
-		FetchedEra {
-			current_active_era: EraIndex,
-		},
-		FetchedOldEra {
-			old_era: EraIndex,
-		},
-		ClearedOldEra {
-			old_era: EraIndex,
-		},
-		HistoryDepth {
-			history_depth: u32,
-		},
+		RewardAmountIsSet { amount: BalanceOf<T> },
+		/// Cluster got update
+		OperatorAssignedEraUpdated { operator_address: T::AccountId, new_era: EraIndex },
+		/// Bonded extra to match default staking amount
+		BondedExtra { operator_address: T::AccountId, amount: BalanceOf<T> },
+		/// Bonded extra to match default staking amount
+		RefundedExcess { operator_address: T::AccountId, amount: BalanceOf<T> },
 	}
 
 	#[pallet::error]
@@ -490,6 +443,16 @@ pub mod pallet {
 		RewardsAlreadyClaimedForEra,
 		/// Insuffience Balance to Bond
 		InsufficientBalanceToBond,
+		/// Operator assigned era not found
+		OperatorAssignedEraNotFound,
+		/// Bond extra not allowed since the current staked amount of operator is not less than
+		/// default staking amount
+		BondExtraNotAllowed,
+		/// Refund excess not allowed since the current staked amount of operator is not higher
+		/// than the default staking amount
+		RefundExcessNotAllowed,
+		/// Force update should have either new enclave address or new api uri to be updated
+		NoUpdatesProvided,
 	}
 
 	#[pallet::call]
@@ -529,7 +492,12 @@ pub mod pallet {
 				new_operator_balance,
 			)?;
 
-			let stake_details = TeeStakingLedger::new(who.clone(), false, Default::default());
+			let stake_details = TeeStakingLedger::new(
+				who.clone(),
+				default_staking_amount.clone(),
+				false,
+				Default::default(),
+			);
 			StakingLedger::<T>::insert(who.clone(), stake_details);
 			T::Currency::set_lock(
 				TEE_STAKING_ID,
@@ -570,15 +538,27 @@ pub mod pallet {
 						Ok(())
 					})?;
 					let now = frame_system::Pallet::<T>::block_number();
-					let stake_details = TeeStakingLedger::new(who.clone(), true, now);
-					StakingLedger::<T>::insert(who.clone(), stake_details);
-					Self::deposit_event(Event::MovedForUnregistration {
-						operator_address: who.clone(),
-					});
-					Self::deposit_event(Event::Unbonded {
-						operator_address: who,
-						amount: default_staking_amount,
-					});
+
+					StakingLedger::<T>::try_mutate(
+						&who,
+						|maybe_stake_details| -> DispatchResult {
+							let stake_details =
+								maybe_stake_details.as_mut().ok_or(Error::<T>::StakingNotFound)?;
+
+							stake_details.is_unlocking = true;
+							stake_details.unbonded_at = now;
+
+							Self::deposit_event(Event::MovedForUnregistration {
+								operator_address: who.clone(),
+							});
+							Self::deposit_event(Event::Unbonded {
+								operator_address: who.clone(),
+								amount: stake_details.staked_amount,
+							});
+
+							Ok(())
+						},
+					)?;
 				},
 				None => {
 					EnclaveRegistrations::<T>::try_mutate(
@@ -593,6 +573,7 @@ pub mod pallet {
 					)?;
 					StakingLedger::<T>::remove(who.clone());
 					T::Currency::remove_lock(TEE_STAKING_ID, &who);
+
 					Self::deposit_event(Event::RegistrationRemoved {
 						operator_address: who.clone(),
 					});
@@ -703,6 +684,15 @@ pub mod pallet {
 						// Add enclave to cluster id
 						EnclaveClusterId::<T>::insert(operator_address.clone(), cluster_id);
 
+						let current_active_era = Staking::<T>::active_era()
+							.map(|e| e.index)
+							.ok_or(Error::<T>::FailedToGetActiveEra)?;
+
+						OperatorAssignedEra::<T>::insert(
+							operator_address.clone(),
+							current_active_era,
+						);
+
 						// Add enclave operator to cluster
 						cluster
 							.enclaves
@@ -734,6 +724,7 @@ pub mod pallet {
 				|maybe_registration| -> DispatchResult {
 					let _ = maybe_registration.as_mut().ok_or(Error::<T>::RegistrationNotFound)?;
 					*maybe_registration = None;
+					T::Currency::remove_lock(TEE_STAKING_ID, &operator_address);
 					Ok(())
 				},
 			)?;
@@ -743,8 +734,8 @@ pub mod pallet {
 		}
 
 		/// Remove an enclave update request from storage
-		#[pallet::weight(T::TeeWeightInfo::remove_update())]
-		pub fn remove_update(
+		#[pallet::weight(T::TeeWeightInfo::reject_update())]
+		pub fn reject_update(
 			origin: OriginFor<T>,
 			operator_address: T::AccountId,
 		) -> DispatchResultWithPostInfo {
@@ -814,6 +805,9 @@ pub mod pallet {
 
 								// Remove the mapping between operator to cluster id
 								EnclaveClusterId::<T>::remove(&operator_address);
+
+								// Remove the mapping between operator to assigned block number
+								OperatorAssignedEra::<T>::remove(&operator_address);
 
 								// Remove the mapping between enclave address to operator address
 								EnclaveAccountOperator::<T>::remove(&enclave.enclave_address);
@@ -891,11 +885,32 @@ pub mod pallet {
 					// Remove the mapping between operator to cluster id
 					EnclaveClusterId::<T>::remove(&operator_address);
 
+					// Remove the mapping between operator to assigned block number
+					OperatorAssignedEra::<T>::remove(&operator_address);
+
 					// Remove the mapping between enclave address to operator address
 					EnclaveAccountOperator::<T>::remove(&enclave.enclave_address);
 
 					Ok(())
 				})?;
+
+				let now = frame_system::Pallet::<T>::block_number();
+				StakingLedger::<T>::try_mutate(
+					&operator_address,
+					|maybe_stake_details| -> DispatchResult {
+						let stake_details =
+							maybe_stake_details.as_mut().ok_or(Error::<T>::StakingNotFound)?;
+						stake_details.is_unlocking = true;
+						stake_details.unbonded_at = now;
+
+						Self::deposit_event(Event::Unbonded {
+							operator_address: operator_address.clone(),
+							amount: stake_details.staked_amount,
+						});
+
+						Ok(())
+					},
+				)?;
 
 				// Remove the enclave data
 				*maybe_enclave = None;
@@ -966,32 +981,47 @@ pub mod pallet {
 		pub fn force_update_enclave(
 			origin: OriginFor<T>,
 			operator_address: T::AccountId,
-			new_enclave_address: T::AccountId,
-			new_api_uri: BoundedVec<u8, T::MaxUriLen>,
+			new_enclave_address: Option<T::AccountId>,
+			new_api_uri: Option<BoundedVec<u8, T::MaxUriLen>>,
 		) -> DispatchResultWithPostInfo {
 			ensure_root(origin)?;
 
-			ensure!(!new_api_uri.is_empty(), Error::<T>::ApiUriIsEmpty);
-			ensure!(operator_address != new_enclave_address, Error::<T>::OperatorAndEnclaveAreSame);
+			// Ensure at least one of the optional parameters is provided
+			ensure!(
+				new_enclave_address.is_some() || new_api_uri.is_some(),
+				Error::<T>::NoUpdatesProvided
+			);
 
 			EnclaveData::<T>::try_mutate(&operator_address, |maybe_enclave| -> DispatchResult {
 				let enclave = maybe_enclave.as_mut().ok_or(Error::<T>::EnclaveNotFound)?;
 
-				if enclave.enclave_address != new_enclave_address {
-					ensure!(
-						EnclaveAccountOperator::<T>::get(&new_enclave_address).is_none(),
-						Error::<T>::EnclaveAddressAlreadyExists
-					);
-					EnclaveAccountOperator::<T>::insert(
-						new_enclave_address.clone(),
-						operator_address.clone(),
-					);
+				// Update enclave address if provided
+				if let Some(address) = new_enclave_address.clone() {
+					ensure!(operator_address != address, Error::<T>::OperatorAndEnclaveAreSame);
+
+					if enclave.enclave_address != address {
+						ensure!(
+							EnclaveAccountOperator::<T>::get(&address).is_none(),
+							Error::<T>::EnclaveAddressAlreadyExists
+						);
+						EnclaveAccountOperator::<T>::insert(
+							address.clone(),
+							operator_address.clone(),
+						);
+					}
+
+					enclave.enclave_address = address.clone();
 				}
 
-				enclave.enclave_address = new_enclave_address.clone();
-				enclave.api_uri = new_api_uri.clone();
+				// Update API URI if provided
+				if let Some(uri) = new_api_uri.clone() {
+					ensure!(!uri.is_empty(), Error::<T>::ApiUriIsEmpty);
+					enclave.api_uri = uri.clone();
+				}
+
 				Ok(())
 			})?;
+
 			EnclaveUpdates::<T>::try_mutate(&operator_address, |maybe_update| -> DispatchResult {
 				if maybe_update.is_some() {
 					*maybe_update = None;
@@ -999,7 +1029,7 @@ pub mod pallet {
 				Ok(())
 			})?;
 
-			Self::deposit_event(Event::EnclaveUpdated {
+			Self::deposit_event(Event::EnclaveForceUpdated {
 				operator_address,
 				new_enclave_address,
 				new_api_uri,
@@ -1032,9 +1062,9 @@ pub mod pallet {
 			ClusterData::<T>::try_mutate(cluster_id, |maybe_cluster| -> DispatchResult {
 				let cluster = maybe_cluster.as_mut().ok_or(Error::<T>::ClusterNotFound)?;
 				cluster.cluster_type = cluster_type.clone();
+				Self::deposit_event(Event::ClusterUpdated { cluster_id, cluster_type });
 				Ok(())
 			})?;
-			Self::deposit_event(Event::ClusterUpdated { cluster_id, cluster_type });
 			Ok(().into())
 		}
 
@@ -1287,9 +1317,14 @@ pub mod pallet {
 			let current_active_era = Staking::<T>::active_era()
 				.map(|e| e.index)
 				.ok_or(Error::<T>::FailedToGetActiveEra)?;
+
+			let operator_assigned_era = OperatorAssignedEra::<T>::get(&who)
+				.ok_or(Error::<T>::OperatorAssignedEraNotFound)?;
+
 			ensure!(
 				era < current_active_era.saturating_sub(2) &&
-					era > current_active_era.saturating_sub(T::TeeHistoryDepth::get()),
+					era > current_active_era.saturating_sub(T::TeeHistoryDepth::get()) &&
+					era >= operator_assigned_era,
 				Error::<T>::InvalidEraToClaimRewards
 			);
 
@@ -1335,6 +1370,106 @@ pub mod pallet {
 					amount: reward_per_operator,
 				});
 			}
+			Ok(().into())
+		}
+
+		// Updates assigned era for an operator
+		#[pallet::weight(T::TeeWeightInfo::update_operator_assigned_era())]
+		pub fn update_operator_assigned_era(
+			origin: OriginFor<T>,
+			operator_address: T::AccountId,
+			new_era: EraIndex,
+		) -> DispatchResultWithPostInfo {
+			ensure_root(origin)?;
+			OperatorAssignedEra::<T>::try_mutate(
+				operator_address.clone(),
+				|maybe_operator| -> DispatchResult {
+					let operator_assigned_era =
+						maybe_operator.as_mut().ok_or(Error::<T>::OperatorAssignedEraNotFound)?;
+					*operator_assigned_era = new_era.clone();
+					Self::deposit_event(Event::OperatorAssignedEraUpdated {
+						operator_address,
+						new_era,
+					});
+					Ok(())
+				},
+			)?;
+			Ok(().into())
+		}
+
+		// Bond extra if the default staking amount is increased
+		#[pallet::weight(T::TeeWeightInfo::bond_extra())]
+		pub fn bond_extra(origin: OriginFor<T>) -> DispatchResultWithPostInfo {
+			let who = ensure_signed(origin)?;
+
+			let default_staking_amount = StakingAmount::<T>::get();
+
+			StakingLedger::<T>::try_mutate(&who, |maybe_stake_details| -> DispatchResult {
+				let stake_details =
+					maybe_stake_details.as_mut().ok_or(Error::<T>::StakingNotFound)?;
+
+				ensure!(
+					stake_details.staked_amount < default_staking_amount,
+					Error::<T>::BondExtraNotAllowed
+				);
+
+				let extra_bond_required =
+					default_staking_amount.saturating_sub(stake_details.staked_amount);
+
+				stake_details.staked_amount = default_staking_amount.clone();
+
+				T::Currency::set_lock(
+					TEE_STAKING_ID,
+					&who,
+					default_staking_amount.clone(),
+					WithdrawReasons::all(),
+				);
+
+				Self::deposit_event(Event::BondedExtra {
+					operator_address: who.clone(),
+					amount: extra_bond_required,
+				});
+
+				Ok(())
+			})?;
+			Ok(().into())
+		}
+
+		// Bond extra if the default staking amount is increased
+		#[pallet::weight(T::TeeWeightInfo::refund_excess())]
+		pub fn refund_excess(origin: OriginFor<T>) -> DispatchResultWithPostInfo {
+			let who = ensure_signed(origin)?;
+
+			let default_staking_amount = StakingAmount::<T>::get();
+
+			StakingLedger::<T>::try_mutate(&who, |maybe_stake_details| -> DispatchResult {
+				let stake_details =
+					maybe_stake_details.as_mut().ok_or(Error::<T>::StakingNotFound)?;
+
+				ensure!(
+					stake_details.staked_amount > default_staking_amount,
+					Error::<T>::RefundExcessNotAllowed
+				);
+
+				let extra_bond_to_be_refunded =
+					stake_details.staked_amount.saturating_sub(default_staking_amount);
+
+				stake_details.staked_amount = default_staking_amount.clone();
+
+				T::Currency::set_lock(
+					TEE_STAKING_ID,
+					&who,
+					default_staking_amount.clone(),
+					WithdrawReasons::all(),
+				);
+
+				Self::deposit_event(Event::RefundedExcess {
+					operator_address: who.clone(),
+					amount: extra_bond_to_be_refunded,
+				});
+
+				Ok(())
+			})?;
 			Ok(().into())
 		}
 	}

--- a/tee/src/lib.rs
+++ b/tee/src/lib.rs
@@ -1466,17 +1466,6 @@ pub mod pallet {
 				let extra_bond_to_be_refunded =
 					stake_details.staked_amount.saturating_sub(default_staking_amount);
 
-				let operator_balance = T::Currency::free_balance(&who);
-				let new_operator_balance = operator_balance
-					.checked_sub(&extra_bond_to_be_refunded)
-					.ok_or(Error::<T>::InsufficientBalanceToBond)?;
-
-				T::Currency::ensure_can_withdraw(
-					&who,
-					extra_bond_to_be_refunded.clone(),
-					WithdrawReasons::all(),
-					new_operator_balance,
-				)?;
 
 				stake_details.staked_amount = default_staking_amount.clone();
 

--- a/tee/src/tests/extrinsics.rs
+++ b/tee/src/tests/extrinsics.rs
@@ -104,6 +104,7 @@ mod register_enclave {
 			.execute_with(|| {
 				let alice: mock::RuntimeOrigin = origin(ALICE);
 				let api_uri: BoundedVec<u8, MaxUriLen> = b"test".to_vec().try_into().unwrap();
+				start_active_era(1);
 
 				assert_ok!(TEE::register_enclave(alice.clone(), CHARLIE, api_uri.clone()));
 				assert_ok!(TEE::create_cluster(root(), ClusterType::Public));
@@ -125,6 +126,7 @@ mod register_enclave {
 				let alice: mock::RuntimeOrigin = origin(ALICE);
 				let bob: mock::RuntimeOrigin = origin(BOB);
 				let api_uri: BoundedVec<u8, MaxUriLen> = b"test".to_vec().try_into().unwrap();
+				start_active_era(1);
 
 				assert_ok!(TEE::create_cluster(root(), ClusterType::Public));
 
@@ -171,6 +173,7 @@ mod unregister_enclave {
 			.execute_with(|| {
 				let alice: mock::RuntimeOrigin = origin(ALICE);
 				let api_uri: BoundedVec<u8, MaxUriLen> = b"test".to_vec().try_into().unwrap();
+				start_active_era(1);
 
 				assert_ok!(TEE::register_enclave(alice.clone(), CHARLIE, api_uri.clone()));
 				assert_ok!(TEE::create_cluster(root(), ClusterType::Public));
@@ -208,6 +211,7 @@ mod update_enclave {
 				let api_uri: BoundedVec<u8, MaxUriLen> = b"test".to_vec().try_into().unwrap();
 				let new_api_uri: BoundedVec<u8, MaxUriLen> =
 					"new_api_uri".as_bytes().to_vec().try_into().unwrap();
+				start_active_era(1);
 
 				assert_ok!(TEE::register_enclave(alice.clone(), CHARLIE, api_uri.clone()));
 				assert_ok!(TEE::create_cluster(root(), ClusterType::Public));
@@ -254,6 +258,7 @@ mod update_enclave {
 				let alice: mock::RuntimeOrigin = origin(ALICE);
 				let new_api_uri: BoundedVec<u8, MaxUriLen> =
 					"new_api_uri".as_bytes().to_vec().try_into().unwrap();
+				start_active_era(1);
 
 				assert_ok!(TEE::register_enclave(alice.clone(), CHARLIE, new_api_uri.clone()));
 				assert_ok!(TEE::create_cluster(root(), ClusterType::Public));
@@ -291,6 +296,7 @@ mod update_enclave {
 				let alice: mock::RuntimeOrigin = origin(ALICE);
 				let eve: mock::RuntimeOrigin = origin(EVE);
 				let api_uri: BoundedVec<u8, MaxUriLen> = b"test".to_vec().try_into().unwrap();
+				start_active_era(1);
 
 				assert_ok!(TEE::create_cluster(root(), ClusterType::Public));
 
@@ -319,6 +325,7 @@ mod cancel_update {
 			.execute_with(|| {
 				let alice: mock::RuntimeOrigin = origin(ALICE);
 				let api_uri: BoundedVec<u8, MaxUriLen> = b"test".to_vec().try_into().unwrap();
+				start_active_era(1);
 
 				assert_ok!(TEE::create_cluster(root(), ClusterType::Public));
 				assert_ok!(TEE::register_enclave(alice.clone(), CHARLIE, api_uri.clone()));
@@ -361,6 +368,7 @@ mod assign_enclave {
 				let api_uri: BoundedVec<u8, MaxUriLen> = b"test".to_vec().try_into().unwrap();
 				let cluster_id = 0u32;
 
+				start_active_era(1);
 				assert_ok!(TEE::register_enclave(alice.clone(), CHARLIE, api_uri.clone()));
 				assert_ok!(TEE::create_cluster(root(), ClusterType::Public));
 				assert_ok!(TEE::assign_enclave(root(), ALICE, cluster_id, 0));
@@ -394,6 +402,8 @@ mod assign_enclave {
 				let alice: mock::RuntimeOrigin = origin(ALICE);
 				let bob: mock::RuntimeOrigin = origin(BOB);
 				let api_uri: BoundedVec<u8, MaxUriLen> = b"test".to_vec().try_into().unwrap();
+
+				start_active_era(1);
 
 				assert_ok!(TEE::register_enclave(alice.clone(), CHARLIE, api_uri.clone()));
 				assert_ok!(TEE::register_enclave(bob.clone(), CHARLIE, api_uri.clone()));
@@ -439,6 +449,8 @@ mod assign_enclave {
 				let bob: mock::RuntimeOrigin = origin(BOB);
 				let charlie: mock::RuntimeOrigin = origin(CHARLIE);
 				let api_uri: BoundedVec<u8, MaxUriLen> = b"test".to_vec().try_into().unwrap();
+
+				start_active_era(1);
 
 				assert_ok!(TEE::register_enclave(alice.clone(), ALICE_ENCLAVE, api_uri.clone()));
 				assert_ok!(TEE::register_enclave(bob.clone(), BOB_ENCLAVE, api_uri.clone()));
@@ -496,6 +508,7 @@ mod reject_update {
 				let api_uri: BoundedVec<u8, MaxUriLen> = b"test".to_vec().try_into().unwrap();
 				let new_api_uri: BoundedVec<u8, MaxUriLen> =
 					"new_api_uri".as_bytes().to_vec().try_into().unwrap();
+				start_active_era(1);
 
 				assert_ok!(TEE::register_enclave(alice.clone(), CHARLIE, api_uri.clone()));
 				assert_ok!(TEE::create_cluster(root(), ClusterType::Public));
@@ -529,6 +542,7 @@ mod reject_update {
 				let api_uri: BoundedVec<u8, MaxUriLen> = b"test".to_vec().try_into().unwrap();
 				let new_api_uri: BoundedVec<u8, MaxUriLen> =
 					"new_api_uri".as_bytes().to_vec().try_into().unwrap();
+				start_active_era(1);
 
 				assert_ok!(TEE::register_enclave(alice.clone(), CHARLIE, api_uri.clone()));
 				assert_ok!(TEE::create_cluster(root(), ClusterType::Public));
@@ -562,6 +576,7 @@ mod approve_enclave_unregistration {
 				let api_uri: BoundedVec<u8, MaxUriLen> = b"test".to_vec().try_into().unwrap();
 				let new_api_uri: BoundedVec<u8, MaxUriLen> =
 					"new_api_uri".as_bytes().to_vec().try_into().unwrap();
+				start_active_era(1);
 				assert_ok!(TEE::register_enclave(alice.clone(), CHARLIE, api_uri.clone()));
 				assert_ok!(TEE::create_cluster(root(), ClusterType::Public));
 				assert_ok!(TEE::assign_enclave(root(), ALICE, 0, 0));
@@ -603,6 +618,7 @@ mod force_remove_enclave {
 				let api_uri: BoundedVec<u8, MaxUriLen> = b"test".to_vec().try_into().unwrap();
 				let new_api_uri: BoundedVec<u8, MaxUriLen> =
 					"new_api_uri".as_bytes().to_vec().try_into().unwrap();
+				start_active_era(1);
 				assert_ok!(TEE::register_enclave(alice.clone(), CHARLIE, api_uri.clone()));
 				assert_ok!(TEE::create_cluster(root(), ClusterType::Public));
 				assert_ok!(TEE::assign_enclave(root(), ALICE, 0, 0));
@@ -644,6 +660,7 @@ mod force_remove_enclave {
 			.execute_with(|| {
 				let alice: mock::RuntimeOrigin = origin(ALICE);
 				let api_uri: BoundedVec<u8, MaxUriLen> = b"test".to_vec().try_into().unwrap();
+				start_active_era(1);
 
 				assert_ok!(TEE::register_enclave(alice.clone(), CHARLIE, api_uri.clone()));
 				assert_ok!(TEE::create_cluster(root(), ClusterType::Public));
@@ -665,6 +682,7 @@ mod force_remove_enclave {
 			.execute_with(|| {
 				let alice: mock::RuntimeOrigin = origin(ALICE);
 				let api_uri: BoundedVec<u8, MaxUriLen> = b"test".to_vec().try_into().unwrap();
+				start_active_era(1);
 
 				assert_ok!(TEE::register_enclave(alice.clone(), CHARLIE, api_uri.clone()));
 				assert_ok!(TEE::create_cluster(root(), ClusterType::Public));
@@ -693,22 +711,28 @@ mod force_update_enclave {
 				let api_uri: BoundedVec<u8, MaxUriLen> = b"test".to_vec().try_into().unwrap();
 				let new_api_uri: BoundedVec<u8, MaxUriLen> =
 					"new_api_uri".as_bytes().to_vec().try_into().unwrap();
+				start_active_era(1);
 
 				assert_ok!(TEE::register_enclave(alice.clone(), CHARLIE, api_uri.clone()));
 				assert_ok!(TEE::create_cluster(root(), ClusterType::Public));
 				assert_ok!(TEE::assign_enclave(root(), ALICE, 0, 0));
 				assert_ok!(TEE::update_enclave(alice.clone(), BOB, new_api_uri.clone()));
 				assert!(EnclaveUpdates::<Test>::get(ALICE).is_some());
-				assert_ok!(TEE::force_update_enclave(root(), ALICE, BOB, new_api_uri.clone()));
+				assert_ok!(TEE::force_update_enclave(
+					root(),
+					ALICE,
+					Some(BOB),
+					Some(new_api_uri.clone())
+				));
 
 				let updated_record = Enclave::new(BOB, new_api_uri.clone());
 				assert_eq!(EnclaveData::<Test>::get(ALICE).unwrap(), updated_record);
 				assert!(EnclaveUpdates::<Test>::get(ALICE).is_none());
 
-				let event = RuntimeEvent::TEE(TEEEvent::EnclaveUpdated {
+				let event = RuntimeEvent::TEE(TEEEvent::EnclaveForceUpdated {
 					operator_address: ALICE,
-					new_enclave_address: BOB,
-					new_api_uri,
+					new_enclave_address: Some(BOB),
+					new_api_uri: Some(new_api_uri),
 				});
 				System::assert_last_event(event);
 			})
@@ -718,7 +742,10 @@ mod force_update_enclave {
 	fn bad_origin() {
 		let api_uri: BoundedVec<u8, MaxUriLen> = b"test".to_vec().try_into().unwrap();
 		ExtBuilder::default().tokens(vec![(ALICE, 1000)]).build().execute_with(|| {
-			assert_noop!(TEE::force_update_enclave(origin(ALICE), ALICE, BOB, api_uri), BadOrigin);
+			assert_noop!(
+				TEE::force_update_enclave(origin(ALICE), ALICE, Some(BOB), Some(api_uri)),
+				BadOrigin
+			);
 		})
 	}
 
@@ -731,6 +758,7 @@ mod force_update_enclave {
 				let alice: mock::RuntimeOrigin = origin(ALICE);
 				let bob: mock::RuntimeOrigin = origin(BOB);
 				let api_uri: BoundedVec<u8, MaxUriLen> = b"test".to_vec().try_into().unwrap();
+				start_active_era(1);
 
 				assert_ok!(TEE::create_cluster(root(), ClusterType::Public));
 
@@ -741,7 +769,7 @@ mod force_update_enclave {
 				assert_ok!(TEE::assign_enclave(root(), BOB, 0, 1));
 
 				assert_noop!(
-					TEE::force_update_enclave(root(), BOB, CHARLIE, api_uri.clone()),
+					TEE::force_update_enclave(root(), BOB, Some(CHARLIE), Some(api_uri.clone())),
 					Error::<Test>::EnclaveAddressAlreadyExists
 				);
 			})
@@ -757,13 +785,19 @@ mod force_update_enclave {
 				let api_uri: BoundedVec<u8, MaxUriLen> = b"test".to_vec().try_into().unwrap();
 				let new_api_uri: BoundedVec<u8, MaxUriLen> =
 					"new_api_uri".as_bytes().to_vec().try_into().unwrap();
+				start_active_era(1);
 
 				assert_ok!(TEE::register_enclave(alice.clone(), CHARLIE, api_uri.clone()));
 				assert_ok!(TEE::create_cluster(root(), ClusterType::Public));
 				assert_ok!(TEE::assign_enclave(root(), ALICE, 0, 0));
 
 				assert_noop!(
-					TEE::force_update_enclave(root(), ALICE, ALICE, new_api_uri.clone(),),
+					TEE::force_update_enclave(
+						root(),
+						ALICE,
+						Some(ALICE),
+						Some(new_api_uri.clone()),
+					),
 					Error::<Test>::OperatorAndEnclaveAreSame
 				);
 			})
@@ -779,13 +813,19 @@ mod force_update_enclave {
 				let api_uri: BoundedVec<u8, MaxUriLen> = b"test".to_vec().try_into().unwrap();
 				let new_api_uri: BoundedVec<u8, MaxUriLen> =
 					"new_api_uri".as_bytes().to_vec().try_into().unwrap();
+				start_active_era(1);
 
 				assert_ok!(TEE::register_enclave(alice.clone(), CHARLIE, api_uri.clone()));
 				assert_ok!(TEE::create_cluster(root(), ClusterType::Public));
 				assert_ok!(TEE::assign_enclave(root(), ALICE, 0, 0));
 
 				assert_noop!(
-					TEE::force_update_enclave(root(), CHARLIE, BOB, new_api_uri.clone(),),
+					TEE::force_update_enclave(
+						root(),
+						CHARLIE,
+						Some(BOB),
+						Some(new_api_uri.clone()),
+					),
 					Error::<Test>::EnclaveNotFound
 				);
 			})
@@ -894,6 +934,7 @@ mod remove_cluster {
 			.execute_with(|| {
 				let alice: mock::RuntimeOrigin = origin(ALICE);
 				let api_uri: BoundedVec<u8, MaxUriLen> = b"test".to_vec().try_into().unwrap();
+				start_active_era(1);
 
 				assert_ok!(TEE::register_enclave(alice.clone(), CHARLIE, api_uri.clone()));
 				assert_ok!(TEE::create_cluster(root(), ClusterType::Public));

--- a/tee/src/tests/extrinsics.rs
+++ b/tee/src/tests/extrinsics.rs
@@ -49,7 +49,7 @@ mod register_enclave {
 				assert!(EnclaveAccountOperator::<Test>::get(ALICE).is_none());
 
 				let expected_stake_details =
-					TeeStakingLedger::new(ALICE, false, Default::default());
+					TeeStakingLedger::new(ALICE, 20, false, Default::default());
 				let actual_stake_details = TEE::tee_staking_ledger(ALICE).unwrap();
 				assert_eq!(expected_stake_details, actual_stake_details);
 
@@ -483,11 +483,11 @@ mod remove_registration {
 	}
 }
 
-mod remove_update {
+mod reject_update {
 	use super::*;
 
 	#[test]
-	fn remove_update() {
+	fn reject_update() {
 		ExtBuilder::default()
 			.tokens(vec![(ALICE, 1000), (CHARLIE, 100)])
 			.build()
@@ -503,7 +503,7 @@ mod remove_update {
 
 				assert_ok!(TEE::update_enclave(alice.clone(), BOB, new_api_uri.clone()));
 
-				assert_ok!(TEE::remove_update(root(), ALICE));
+				assert_ok!(TEE::reject_update(root(), ALICE));
 				assert!(EnclaveUpdates::<Test>::get(ALICE).is_none());
 
 				let event =
@@ -515,12 +515,12 @@ mod remove_update {
 	#[test]
 	fn bad_origin() {
 		ExtBuilder::default().tokens(vec![(ALICE, 1000)]).build().execute_with(|| {
-			assert_noop!(TEE::remove_update(origin(ALICE), ALICE), BadOrigin);
+			assert_noop!(TEE::reject_update(origin(ALICE), ALICE), BadOrigin);
 		})
 	}
 
 	#[test]
-	fn remove_update_with_invalid_operator() {
+	fn reject_update_with_invalid_operator() {
 		ExtBuilder::default()
 			.tokens(vec![(ALICE, 1000), (CHARLIE, 100)])
 			.build()
@@ -536,7 +536,7 @@ mod remove_update {
 
 				assert_ok!(TEE::update_enclave(alice.clone(), BOB, new_api_uri.clone()));
 
-				assert_noop!(TEE::remove_update(root(), BOB), Error::<Test>::UpdateRequestNotFound);
+				assert_noop!(TEE::reject_update(root(), BOB), Error::<Test>::UpdateRequestNotFound);
 				assert!(EnclaveUpdates::<Test>::get(ALICE).is_some());
 
 				let event = RuntimeEvent::TEE(TEEEvent::MovedForUpdate {

--- a/tee/src/tests/traits.rs
+++ b/tee/src/tests/traits.rs
@@ -36,6 +36,7 @@ fn ensure_enclave() {
 			let bob: mock::RuntimeOrigin = RawOrigin::Signed(BOB).into();
 			let cluster_id: ClusterId = 0;
 			let api_uri: BoundedVec<u8, MaxUriLen> = b"test".to_vec().try_into().unwrap();
+			start_active_era(1);
 
 			assert_ok!(TEE::create_cluster(root(), crate::ClusterType::Public));
 			assert_ok!(TEE::register_enclave(alice.clone(), ALICE_ENCLAVE, api_uri.clone()));

--- a/tee/src/types.rs
+++ b/tee/src/types.rs
@@ -85,27 +85,36 @@ where
 #[derive(
 	PartialEqNoBound, CloneNoBound, Encode, Decode, RuntimeDebugNoBound, TypeInfo, MaxEncodedLen,
 )]
-#[codec(mel_bound(AccountId: MaxEncodedLen, BlockNumber: MaxEncodedLen))]
-pub struct TeeStakingLedger<AccountId, BlockNumber>
+#[codec(mel_bound(AccountId: MaxEncodedLen, BlockNumber: MaxEncodedLen, Balance: MaxEncodedLen))]
+pub struct TeeStakingLedger<AccountId, BlockNumber, Balance>
 where
 	AccountId: Clone + PartialEq + Debug,
 	BlockNumber: Clone + PartialEq + Debug + sp_std::cmp::PartialOrd + AtLeast32BitUnsigned + Copy,
+	Balance: Clone + PartialEq + Debug + sp_std::cmp::PartialOrd,
 {
 	/// The operator account whose balance is actually locked and at stake.
 	pub operator: AccountId,
+	/// The total staked amount
+	pub staked_amount: Balance,
 	/// State variable to know whether the staked amount is unbonded
 	pub is_unlocking: bool,
 	/// Block Number of when unbonded happened
 	pub unbonded_at: BlockNumber,
 }
 
-impl<AccountId, BlockNumber> TeeStakingLedger<AccountId, BlockNumber>
+impl<AccountId, BlockNumber, Balance> TeeStakingLedger<AccountId, BlockNumber, Balance>
 where
 	AccountId: Clone + PartialEq + Debug,
 	BlockNumber: Clone + PartialEq + Debug + sp_std::cmp::PartialOrd + AtLeast32BitUnsigned + Copy,
+	Balance: Clone + PartialEq + Debug + sp_std::cmp::PartialOrd,
 {
-	pub fn new(operator: AccountId, is_unlocking: bool, unbonded_at: BlockNumber) -> Self {
-		Self { operator, is_unlocking, unbonded_at }
+	pub fn new(
+		operator: AccountId,
+		staked_amount: Balance,
+		is_unlocking: bool,
+		unbonded_at: BlockNumber,
+	) -> Self {
+		Self { operator, staked_amount, is_unlocking, unbonded_at }
 	}
 }
 // #[derive(Clone, Eq, PartialEq, Encode, Decode, Default, RuntimeDebug, TypeInfo, MaxEncodedLen)]

--- a/tee/src/weights.rs
+++ b/tee/src/weights.rs
@@ -24,7 +24,7 @@ pub trait WeightInfo {
 	fn assign_enclave() -> Weight;
 	fn remove_enclave() -> Weight;
 	fn remove_registration() -> Weight;
-	fn remove_update() -> Weight;
+	fn reject_update() -> Weight;
 	fn force_update_enclave() -> Weight;
 	fn create_cluster() -> Weight;
 	fn update_cluster() -> Weight;
@@ -38,6 +38,9 @@ pub trait WeightInfo {
 	fn set_staking_amount() -> Weight;
 	fn set_daily_reward_pool() -> Weight;
 	fn claim_rewards() -> Weight;
+	fn update_operator_assigned_era() -> Weight;
+	fn bond_extra() -> Weight;
+	fn refund_excess() -> Weight;
 }
 
 impl WeightInfo for () {
@@ -74,7 +77,7 @@ impl WeightInfo for () {
 	fn remove_cluster() -> Weight {
 		Weight::from_ref_time(10_000_000 as u64)
 	}
-	fn remove_update() -> Weight {
+	fn reject_update() -> Weight {
 		Weight::from_ref_time(10_000_000 as u64)
 	}
 	fn withdraw_unbonded() -> Weight {
@@ -102,6 +105,15 @@ impl WeightInfo for () {
 		Weight::from_ref_time(10_000_000 as u64)
 	}
 	fn claim_rewards() -> Weight {
+		Weight::from_ref_time(10_000_000 as u64)
+	}
+	fn update_operator_assigned_era() -> Weight {
+		Weight::from_ref_time(10_000_000 as u64)
+	}
+	fn bond_extra() -> Weight {
+		Weight::from_ref_time(10_000_000 as u64)
+	}
+	fn refund_excess() -> Weight {
 		Weight::from_ref_time(10_000_000 as u64)
 	}
 }


### PR DESCRIPTION
Bug fixes and changes includes :

1. Release locked funds in removeregistration
2. Add new map to store approved era for each operator.
3. In claimrewards, check if the claimed era is before the approved era. Then reject
4. In forceupdateenclave make all parameters optional except operator address
5. Add a root call to update approved block number for operator
6. In force remove enclave unbending period should start when the TC initiates this request
7. Rename remove update to reject update
8. Update event when unbonding, with actual locked amount (achieved by new field added in TeeStakingLedger)
9. Two extrinsic needed to bondExtra and refundExcess